### PR TITLE
RIDI PAY 설정 시스템 및 단건 결제 API 구현

### DIFF
--- a/tests/src/Dummy/DummyController.php
+++ b/tests/src/Dummy/DummyController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace RidiPay\Tests\Dummy;
 
 use RidiPay\Library\Jwt\Annotation\JwtAuth;
+use RidiPay\Library\OAuth2\Annotation\OAuth2;
 use RidiPay\Library\Validation\Annotation\ParamValidator;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,6 +21,18 @@ class DummyController extends Controller
      * @return Response
      */
     public function jwtAuthTest(Request $request): Response
+    {
+        return new Response();
+    }
+
+    /**
+     * @Route("/oauth2", methods={"GET"})
+     * @OAuth2()
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function oauth2Test(Request $request): Response
     {
         return new Response();
     }

--- a/tests/src/OAuth2MiddlewareTest.php
+++ b/tests/src/OAuth2MiddlewareTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace RidiPay\Tests;
+
+use AspectMock\Test;
+use Firebase\JWT\JWT;
+use Ridibooks\OAuth2\Constant\AccessTokenConstant;
+use RidiPay\Library\OAuth2\User\DefaultUserProvider;
+use RidiPay\Library\OAuth2\User\User;
+use RidiPay\Tests\Dummy\DummyKernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class OAuth2MiddlewareTest extends WebTestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Test::double(
+            DefaultUserProvider::class,
+            [
+                'getUser' => new User(json_encode([
+                    'result' => [
+                        'idx' => 123456,
+                        'id' => 'dummy'
+                    ]
+                ]))
+            ]
+        );
+    }
+
+    public static function tearDownAfterClass()
+    {
+        Test::clean(DefaultUserProvider::class);
+    }
+
+    /**
+     * @param array $options
+     * @return DummyKernel
+     */
+    protected static function createKernel(array $options = []): DummyKernel
+    {
+        return new DummyKernel(getenv('APP_ENV'), true);
+    }
+
+    /**
+     * @dataProvider cookieProvider
+     *
+     * @param null|Cookie $cookie
+     * @param int $http_status_code
+     */
+    public function testMiddleware(?Cookie $cookie, int $http_status_code)
+    {
+        $client = self::createClient();
+        if (!is_null($cookie)) {
+            $client->getCookieJar()->set($cookie);
+        }
+
+        $client->request(Request::METHOD_GET, '/oauth2');
+        $this->assertSame($http_status_code, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @return array
+     * @throws \Exception
+     */
+    public function cookieProvider(): array
+    {
+        return [
+            [new Cookie(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY, getenv('OAUTH2_ACCESS_TOKEN')), Response::HTTP_OK],
+            [new Cookie(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY, JWT::encode(['dummy' => '123'], 'dummy_key')), Response::HTTP_UNAUTHORIZED],
+            [null, Response::HTTP_UNAUTHORIZED],
+        ];
+    }
+}


### PR DESCRIPTION
기존 작업 코드가 master 브랜치에 있어서, https://github.com/ridi-pay/backend/pull/1 PR은 close하고 새로 PR을 열었습니다.

### 내용
- 카드 등록/삭제
- 결제 수단 조회 API For 리디북스
- 결제 비밀번호(PIN) 등록/변경
- 결제 비밀번호(PIN)/계정 비밀번호 검증
- 결제 비밀번호(PIN)/계정 비밀번호 오입력 제한
- 원터치 결제 이용 여부 변경
- Transaction 예약
- Transaction 생성
- Transaction 승인
- Transaction 취소
- Transaction 상태 조회
- AWS Parameter Store 연동
- Symfony4 기반 OAuth2 Middleware 구현
- Symfony4 기반 JWT 검증 Middleware 구현
- Symfony4 기반 HTTP Request Parameter Validation Middleware 구현
- KCP Wrapping Library 구현

### 중점적으로 확인이 필요한 사항
- Transaction 관련 로직
  - 가맹점 - RIDI Pay - PG사 간 연동 상황에서 결제 무결성 확보를 위해 보강하면 좋을 부분이 있을지
- 유효성 검사가 필요한 것 같은데, 누락된 부분이 있는지
- 보안 측면에서 수정이 필요한 부분이 있는지
- 요구 사항과 구현 사항이 다른 부분이 있는지

### 유의 사항
- `src/Library/OAuth2` 하위 코드는 리뷰하지 않으셔도 됩니다. 추후 [ridi/php-oauth2](https://github.com/ridi/php-oauth2)로 이전할 예정입니다. 해당 repo에서 코드 리뷰를 진행할 예정입니다.
- 쿼리 Explain 및 성능 최적화는 아직 진행하지 못했습니다. 리뷰 혹은 개발 중 쿼리가 수정될 가능성이 있어서, 기능 구현의 거의 완료되는 시점이 되면 확인해볼 예정입니다.

### 로컬 환경 실행
`README.md`를 참고해주세요.

### PHPUNIT
- `README.md` 셋팅 후, `make phpunit` 실행